### PR TITLE
chore:remove https:// prepending from urls

### DIFF
--- a/hooks/addon-login~li.pm
+++ b/hooks/addon-login~li.pm
@@ -50,7 +50,7 @@ sub perform {
 
 	# Confirm before proceeding
 	unless ($non_interactive) {
-		info("\nAbout to log into Doomsday at #C{https://$url} as #M{$username}.\n");
+		info("\nAbout to log into Doomsday at #C{$url} as #M{$username}.\n");
 		my $continue = prompt_for_boolean("Proceed? [y|n]", 1);
 		return $self->done(0) unless $continue;
 	}

--- a/hooks/addon-open~o.pm
+++ b/hooks/addon-open~o.pm
@@ -55,7 +55,7 @@ sub perform {
     "\nDoomsday Web UI Credentials:\n".
     "\tusername: #M{$username}\n".
     "\tpassword: #G{$password}\n\n".
-    "Opening Doomsday Web UI at #C{https://$url} in your browser...\n"
+    "Opening Doomsday Web UI at #C{$url} in your browser...\n"
   );
 
 	# Check if command exists
@@ -64,7 +64,7 @@ sub perform {
 		info("$open_cmd command not found, skipping system opening.") if $rc;
 	} else {
 		info("Opening browser...");
-		system("$open_cmd https://$url >/dev/null 2>&1");
+		system("$open_cmd $url >/dev/null 2>&1");
 	}
 
   return $self->done();


### PR DESCRIPTION
We are currently adding https:// within the url var itself in the doomsday  manifest resulting in dual prints.