### PR TITLE
Cut v1.0.3 release

### DIFF
--- a/hooks/addon-login~li.pm
+++ b/hooks/addon-login~li.pm
@@ -1,5 +1,5 @@
 # vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:
-package Genesis::Hook::Addon::Doomsday::Login v1.0.2;
+package Genesis::Hook::Addon::Doomsday::Login v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-open~o.pm
+++ b/hooks/addon-open~o.pm
@@ -1,5 +1,5 @@
 # vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:
-package Genesis::Hook::Addon::Doomsday::Open v1.0.2;
+package Genesis::Hook::Addon::Doomsday::Open v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/addon-setup-approle~ar.pm
+++ b/hooks/addon-setup-approle~ar.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Addon::Doomsday::SetupApprole v1.0.2;
+package Genesis::Hook::Addon::Doomsday::SetupApprole v1.0.3;
 
 use v5.20;
 use warnings; # Genesis min perl version is 5.20

--- a/hooks/blueprint.pm
+++ b/hooks/blueprint.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Blueprint::Doomsday v1.0.2;
+package Genesis::Hook::Blueprint::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;    # Genesis min perl version is 5.20

--- a/hooks/check.pm
+++ b/hooks/check.pm
@@ -1,5 +1,5 @@
 # vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:
-package Genesis::Hook::Check::Doomsday v1.0.2;
+package Genesis::Hook::Check::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/cloud-config.pm
+++ b/hooks/cloud-config.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::CloudConfig::Doomsday v1.0.2;
+package Genesis::Hook::CloudConfig::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/features.pm
+++ b/hooks/features.pm
@@ -1,5 +1,5 @@
 # vim: set ts=2 sw=2 sts=2 noet fdm=marker foldlevel=1:
-package Genesis::Hook::Features::Doomsday v1.0.2;
+package Genesis::Hook::Features::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/info.pm
+++ b/hooks/info.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::Info::Doomsday v1.0.2;
+package Genesis::Hook::Info::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/new.pm
+++ b/hooks/new.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::New::Doomsday v1.0.2;
+package Genesis::Hook::New::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/hooks/post-deploy.pm
+++ b/hooks/post-deploy.pm
@@ -1,4 +1,4 @@
-package Genesis::Hook::PostDeploy::Doomsday v1.0.2;
+package Genesis::Hook::PostDeploy::Doomsday v1.0.3;
 
 use v5.20;
 use warnings;

--- a/kit.yml
+++ b/kit.yml
@@ -1,5 +1,5 @@
 name:    doomsday
-version: 1.0.2
+version: 1.0.3
 author:  Norman Abramovitz <norm@starkandwayne.com>
          Wayne E. Seguin <wayneeseguin@gmail.com>
 docs:    https://github.com/cloudfoundry-community/doomsday-boshrelease

--- a/manifests/releases/doomsday.yml
+++ b/manifests/releases/doomsday.yml
@@ -1,5 +1,5 @@
 releases:
 - name:    doomsday
-  version: 0.9.7
-  url:     https://github.com/RubidiumStudios/doomsday-boshrelease/releases/download/v0.9.7/doomsday-0.9.7.tgz
-  sha1:    d893fc9acc4c7b433fd551ca2fa13462cf1d8666
+  version: 0.9.8
+  url:     https://github.com/cloudfoundry-community/doomsday-boshrelease/releases/download/v0.9.8/doomsday-0.9.8.tgz
+  sha1:    aaa73a9ee876524c3a8a2a7374eaef0a9d874e05


### PR DESCRIPTION
Pin the doomsday boshrelease to v0.9.8 and bump the kit to
v1.0.3 (release-pin patch; no params, manifest structure, or
hook-logic changes).